### PR TITLE
Fix  the case when origchangeset.get(pkg) returns None

### DIFF
--- a/smart/transaction.py
+++ b/smart/transaction.py
@@ -1028,7 +1028,8 @@ class Transaction(object):
         for pkg in changeset.keys():
 
             op = changeset.get(pkg)
-            if (op and op != origchangeset.get(pkg) and
+	    origpkgop = origchangeset.get(pkg)
+            if (op and origpkgop != None and op != origpkgop and
                 pkg not in locked and pkg not in lockedstates):
 
                 try:


### PR DESCRIPTION
We discovered this issue https://github.com/smartpm/smart/issues/11 some years ago on Endian Appliances while doing tests with multiple channels [issue in our bug tracker](https://jira.endian.com/browse/CORE-474)
We reported it to Launchpad and applied the patch on our previous build system and on all our appliances that are working fine since then.

Unfortunately the patch has never been accepted/discussed upstream and we're now experiencing again the issue with the new Yocto based build system.

patch by Peter Warasin peter@endian.com
https://bugs.launchpad.net/smart/+bug/1181251